### PR TITLE
Drop 'phpoffice/phpexcel' for 'phpoffice/phpspreadsheet' instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "dracoblue/naith": "^1.1",
-        "phpoffice/phpexcel": "^1.7",
+        "phpoffice/phpspreadsheet": "^1.12",
         "symfony/yaml": "^2.0 || ^3.0 || ^4.0"
     },
     "autoload": {
@@ -21,5 +21,7 @@
     "config": {
         "bin-dir": "bin/"
      },
-    "bin": [ "bin/craur" ]
+    "bin": [ "bin/craur" ],
+    "require-dev": {
+    }
 }

--- a/src/Craur.php
+++ b/src/Craur.php
@@ -292,7 +292,9 @@ class Craur
      *             assert(in_array($author->get('name'), array('Hans', 'Paul', 'Erwin')));
      *         }
      *     }
-     * 
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     *
      * @return Craur  
      */
     static function createFromExcelFile($file_path, array $field_mappings)
@@ -310,7 +312,8 @@ class Craur
         
         $entries = array();
 
-        $excel_object = PHPExcel_IOFactory::load($file_path);
+        $excel_type = \PhpOffice\PhpSpreadsheet\IOFactory::identify($file_path);
+        $excel_object = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($excel_type)->load($file_path);
         
         $rows = $excel_object->getActiveSheet()->toArray(null,true,true,true);
         


### PR DESCRIPTION
Note: The new up to date dependency requires `ext-zip`. IDK if this is important to know for you.